### PR TITLE
Implement offline mode

### DIFF
--- a/ChessBoard.java
+++ b/ChessBoard.java
@@ -211,7 +211,7 @@ public class ChessBoard extends GridPane
         
         // Check for null move
         if (p == null) { return false; }
-       
+        
         // Note: Ideally we would check the space coordinates
         //       beforehand, but the try-catch blocks below were
         //       easier to implement.

--- a/ChessGUI.java
+++ b/ChessGUI.java
@@ -74,7 +74,7 @@ public class ChessGUI extends Application
             // create chat box
             VBox chatBox = generateChatBox();
             root.setRight(chatBox);
-            
+
             if (playerIsWhite)
             {
                 connection = createServer();
@@ -85,7 +85,7 @@ public class ChessGUI extends Application
                 connection = createClient();
                 chatArea.appendText("Connecting to server...\n");
             }
-    
+
             try
             {
                 connection.startConnection();


### PR DESCRIPTION
Adds an "offline" option when choosing team color. Allows a chess game to be played locally without sending moves to the other player.

Menu options are now "White (Server)", "Black (Client)", and "Offline"

Note: Just like when playing online, there is no player color checking, so both players can move either team's pieces.

